### PR TITLE
Fix augment list.

### DIFF
--- a/battlearena/characters.als
+++ b/battlearena/characters.als
@@ -1215,7 +1215,7 @@ augments.list {
     while (%value <= %number.of.weapons) {
       set %weapon.name $gettok(%display.weaponlist, %value, 46)
       set %weapon.name $gettok(%weapon.name,1, 40)
-      set %weapon_augment $readini($char($1), augments, %weapon.name)
+      set %weapon_augment $readini($char($1), augments, $strip(%weapon.name))
 
       if (%weapon_augment != $null) { 
         inc %number.of.augments 1


### PR DESCRIPTION
This commit fixes the `!augment list` command.
It looks to me like mIRC 6 strips colour codes from the inputs to `$readini`, whereas mIRC 7 doesn't do that. In any case, we should strip them, because the character file doesn't have that bold code in it.
