### PR TITLE
DCC related fixes and enhancements

### DIFF
--- a/battlearena/characters.mrc
+++ b/battlearena/characters.mrc
@@ -151,8 +151,8 @@ ON 1:TEXT:!quick id*:*:{ $idcheck($nick , $3, quickid) | mode %battlechan +v $ni
   unset %passhurt 
   /close -m* 
 }
-on 3:TEXT:!logout*:*:{ .auser 1 $nick | mode %battlechan -v $nick | .flush 1 }
-on 3:TEXT:!log out*:*:{ .auser 1 $nick | mode %battlechan -v $nick | .flush 1 }
+on 3:TEXT:!logout*:*:{ .auser 1 $nick | close -c $nick | mode %battlechan -v $nick | .flush 1 }
+on 3:TEXT:!log out*:*:{ .auser 1 $nick | close -c $nick | mode %battlechan -v $nick | .flush 1 }
 
 ON 2:TEXT:!last seen *:*:{  $checkchar($3)
   var %last.seen $readini($char($3), info, lastseen)

--- a/battlearena/dccchat.mrc
+++ b/battlearena/dccchat.mrc
@@ -23,6 +23,8 @@ on 3:TEXT:!dcc*:*:{
 ; Enter the DCC chat
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 on 2:open:=: {
+  msg $nick $readini(translation.dat, System, DccConnected)
+
   var %p 1 | var %where $readini($char($nick), DCCchat, Room)
   if (%where = $null) { writeini $char($nick) DCCchat Room Lobby | var %where Lobby }
   if ((%where = BattleRoom) && (%battleis = off)) { writeini $char($nick) DCCchat Room Lobby | var %where Lobby }
@@ -70,7 +72,9 @@ on 2:close:=: { var %p 1
     else {  msg = $+ $chat(%p) 14###4 $nick has left the game. | inc %p 1 }
   }
   close -c $nick
-  .auser 1 $nick | mode %battlechan -v $nick | .flush 1
+  if ($readini(system.dat, system, botType) == DCCChat) {
+    .auser 1 $nick | mode %battlechan -v $nick | .flush 1
+  }
 }
 
 

--- a/battlearena/systemaliases.als
+++ b/battlearena/systemaliases.als
@@ -850,15 +850,15 @@ display.private.message {
   if ($allowcolors = false) { var %message.to.display $strip(%message.to.display, c) }
   if ($allowbold = false) { var %message.to.display $strip(%message.to.display, b) }
 
-  if ($readini(system.dat, system, botType) = IRC) {
+  if (($event == chat) || ($readini(system.dat, system, botType) = DCCchat)) $dcc.private.message($nick, %message.to.display)
+  elseif ($readini(system.dat, system, botType) = IRC) {
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 1 /.msg $nick %message.to.display
   }
-  if ($readini(system.dat, system, botType) = TWITCH) { 
+  elseif ($readini(system.dat, system, botType) = TWITCH) {
     var %twitch.delay $readini(system.dat, system, TwitchDelayTime)
     if (%twitch.delay = $null) { var %twitch.delay 2 }
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 %twitch.delay /query %battlechan %message.to.display
   }
-  if ($readini(system.dat, system, botType) = DCCchat) { $dcc.private.message($nick, %message.to.display) }
 }
 display.private.message2 {
   var %message.to.display $2-
@@ -866,27 +866,26 @@ display.private.message2 {
   if ($allowcolors = false) { var %message.to.display $strip(%message.to.display, c) }
   if ($allowbold = false) { var %message.to.display $strip(%message.to.display, b) }
 
-  if ($readini(system.dat, system, botType) = IRC) {
+  if (($event == chat) || ($readini(system.dat, system, botType) = DCCchat)) $dcc.private.message($1, %message.to.display)
+  elseif ($readini(system.dat, system, botType) = IRC) {
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 1 /.msg $1 %message.to.display 
   }
-  if ($readini(system.dat, system, botType) = TWITCH) { 
+  elseif ($readini(system.dat, system, botType) = TWITCH) {
     var %twitch.delay $readini(system.dat, system, TwitchDelayTime)
     if (%twitch.delay = $null) { var %twitch.delay 2 }
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 %twitch.delay /query %battlechan %message.to.display
   }
-  if ($readini(system.dat, system, botType) = DCCchat) { $dcc.private.message($1, %message.to.display) }
 }
 display.private.message.delay {
   var %message.to.display $1
   if ($allowcolors = false) { var %message.to.display $strip(%message.to.display, c) }
   if ($allowbold = false) { var %message.to.display $strip(%message.to.display, b) }
 
-  if ($readini(system.dat, system, botType) = IRC) {
+  if (($event == chat) || ($readini(system.dat, system, botType) = DCCchat)) $dcc.private.message($nick, %message.to.display)
+  elseif ($readini(system.dat, system, botType) = IRC) {
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 2 /.msg $nick %message.to.display 
   }
-  if ($readini(system.dat, system, botType) = DCCchat) { $dcc.private.message($nick, %message.to.display) }
-
-  if ($readini(system.dat, system, botType) = TWITCH) { 
+  elseif ($readini(system.dat, system, botType) = TWITCH) {
     var %twitch.delay $readini(system.dat, system, TwitchDelayTime)
     if (%twitch.delay = $null) { var %twitch.delay 2 }
     inc %twitch.delay 1 
@@ -899,12 +898,11 @@ display.private.message.delay.custom {
   if ($allowcolors = false) { var %message.to.display $strip(%message.to.display, c) }
   if ($allowbold = false) { var %message.to.display $strip(%message.to.display, b) }
 
-  if ($readini(system.dat, system, botType) = IRC) {
+  if (($event == chat) || ($readini(system.dat, system, botType) = DCCchat)) $dcc.private.message($nick, %message.to.display)
+  elseif ($readini(system.dat, system, botType) = IRC) {
     /.timerDisplayPM $+ $rand(1,1000) $+ $rand(a,z) $+ $rand(1,1000) -d 1 $2 /.msg $nick %message.to.display 
   }
-  if ($readini(system.dat, system, botType) = DCCchat) { $dcc.private.message($nick, %message.to.display) }
-
-  if ($readini(system.dat, system, botType) = TWITCH) { 
+  elseif ($readini(system.dat, system, botType) = TWITCH) {
     var %twitch.delay $readini(system.dat, system, TwitchDelayTime)
     if (%twitch.delay = $null) { var %twitch.delay 2 }
     inc %twitch.delay $2

--- a/battlearena/translation.dat
+++ b/battlearena/translation.dat
@@ -42,6 +42,7 @@ ChangeTimeForEnter=$chr(3) $+ 4 $+ Time allowed for the !enter period has been s
 PlayerExists=$chr(3) $+ 4 $+ A character with the name $nick already exists.  If this is you, use the !id command with your password in query to log in.  If not, please change your nick and try again.
 NameReserved=$chr(3) $+ 4 $+ A character with the name $nick is reserved and cannot be used. Please change your nick and try again.
 CharacterCreated=$chr(3) $+ 3 $+  $+ $nick has entered the dimensional rift to join the battle arena.
+DccConnected=Received your DCC CHAT connection from $address $+ . Use !logout if this is not you.
 StartingCharOrbs=$chr(3) $+ 2 $+ You enter the arena with a total of %starting.orbs  $+ $readini(system.dat, system, currency) to spend.  
 StartingCharPassword=$chr(3) $+ 2 $+ Your password has been set to %password and it is recommended you change it using the command !newpass %password newpasswordhere in private or at least write the password down. $chr(3) $+ Passwords cannot be recovered!
 UnZappedComplete=$chr(3) $+ 10 $+ $+ %real.name has been restored to this dimension. 


### PR DESCRIPTION
The intent behind the **!dcc** command was to allow transactions such as shopping, that result in a lot of private messages, to take place outside of IRC.
This commit reroutes private messages in response to a DCC CHAT to the said DCC CHAT, instead of IRC.
It also lets players know if someone else connects to their DCC session.
