### PR TITLE
Possible fix for auction house

### DIFF
--- a/battlearena/auctionhouse.mrc
+++ b/battlearena/auctionhouse.mrc
@@ -59,27 +59,17 @@ alias auctionhouse.winners {
 
   if ($2 != $null) {
     if ($2 !isnum) { $display.private.message2($1, 4Error: Must input a number) | halt }
-    if ($2 = $readini(system.dat, auctionInfo, numberOfAuctions)) { $display.private.messagee2($1, 4Error: This auction is still live and cannot be checked with this command.) | halt }
-
-    var %auction.lines $lines($txtfile(auction_winners.txt)) 
-    var %current.line 1
-    while (%current.line <= %auction.lines) {
-      var %winner.auctionline $read -l $+ %current.line $txtfile(auction_winners.txt)
-      var %auction.number $gettok(%winner.auctionline, 1, 45)
-
-      if ($2 = %auction.number) { 
-        var %winner.displayline 3Auction No. - Date - Time - Winner - Item - Notes Paid
-        $display.private.message2($1, %winner.displayline)
-        $display.private.message2($1, %winner.auctionline)
-        halt
-      }
-
-      inc %current.line
+    if ($2 = $readini(system.dat, auctionInfo, NumberOfAuctions)) { $display.private.message2($1, 4Error: This auction is still live and cannot be checked with this command.) | halt }
+    if ($2 > $readini(system.dat, auctionInfo, NumberOfAuctions)) { $display.private.message2($1, 4Error: This auction doesn't exist.) | halt }
+    var %auction.number $2
+    while ($len(%auction.number) != 5) {
+      var %auction.number 0 $+ %auction.number
     }
-
-    $display.private.message2($1, 4Error: Invalid auction number) | halt 
+    var %winner.displayline 3Auction No. - Date - Time - Winner - Item - Notes Paid
+    var %winner.auctionline $read($txtfile(auction_winners.txt),nw,%auction.number $+ *)
+    $display.private.message2($1, %winner.displayline)
+    $display.private.message2($1, %winner.auctionline)
   }
-
 }
 
 ; Bid on an item


### PR DESCRIPTION
So, this is simple "derpy" fix for auction winners command, which has one important advantage - works :-).
Tested with generated auction_winners.txt which contained more than 12k auctions in history - works like a charm for me, and should close #15 
```
<Pentium320> !auction winners 12818
<BattleArena> Error: This auction is still live and cannot be checked with this command.
<Pentium320> !auction winners 12817
<BattleArena> Auction No. - Date - Time - Winner - Item - Notes Paid
<BattleArena> 12817 - 01/12/2016 - 23:15:41 - No Winner - FireMod
<Pentium320> !auction winners 12000
<BattleArena> Auction No. - Date - Time - Winner - Item - Notes Paid
<BattleArena> 12000 - 01/12/2016 - 23:01:48 - No Winner - Brown-Belt
<Pentium320> !auction winners 1
<BattleArena> Auction No. - Date - Time - Winner - Item - Notes Paid
<BattleArena> 00001 - 24/11/2016 - 21:17:08 - No Winner - NewsOrb
<Pentium320> !auction winners 4649
<BattleArena> Auction No. - Date - Time - Winner - Item - Notes Paid
<BattleArena> 04649 - 01/12/2016 - 20:54:13 - No Winner - ExplosionMod
```