### PR TITLE
Fix for alchemy skill

### DIFF
--- a/battlearena/skills.mrc
+++ b/battlearena/skills.mrc
@@ -2291,7 +2291,10 @@ alias skill.alchemy {
   if (%gem.required = $null) { unset %gem.required | $display.message($readini(translation.dat, errors, CannotCraftThisItem),private) | halt }
 
   var %amount.to.craft $abs($3)
-  if (%amount.to.craft = $null) { var %amount.to.craft 1 }
+  if ($3 !isnum) {
+    if (%amount.to.craft = $null) { var %amount.to.craft 1 }
+    else { $display.message($readini(translation.dat, errors, NotAValidAmount),private) | halt }
+  }
 
   ; Does the user have the gem necessary to craft the item?
   var %player.gem.amount $readini($char($1), item_amount, %gem.required)  

--- a/battlearena/translation.dat
+++ b/battlearena/translation.dat
@@ -481,6 +481,7 @@ can'tGiveOrbsToThatchar=$chr(3) $+ 4 $+ Error: %real.name cannot give orbs to 
 CannotGiveThatMuchofItem=$chr(3) $+ 4 $+ Error: %real.name does not have $3 of $4 to give!
 CannotGiveToYourself=$chr(3) $+ 4 $+ Error: %real.name cannot give items to $gender2($1) $+ self.
 CannotCraftThisItem=$chr(3) $+ 4 $+ Error: This item cannot be made via alchemy.
+NotAValidAmount=$chr(3) $+ 4 $+ Error: You haven't provided valid amount for alchemy.
 MissingCorrectGem=$chr(3) $+ 4 $+ Error: %real.name is missing the correct gem to craft a $2 $+ !
 MissingIngredients=$chr(3) $+ 4 $+ Error: %real.name is missing the correct ingredients to craft a $2 $+ ! (If the item is an accessory or armor, make sure the ingredient is not equipped)
 PlayersCannotUseSkill=$chr(3) $+ 4 $+ Error: Players are unable to use this skill!


### PR DESCRIPTION
Shows error, if provided something other, than number.

Well, currently nothing terrific happens, if provided something "weird", only bot stucks:
```
<Pentium320> !count death'sbreath
<BattleArena> Pentium320 has 79 death'sbreaths
<Pentium320> !craft tormentorb1 test
<BattleArena> Pentium320 uses the power of the gem to combine ingredients in an attempt to create something better!
<Pentium320> !count death'sbreath
<BattleArena> Pentium320 has 79 death'sbreaths
```
though, I think better to fix it.