### PR TITLE
Fix for +stat items

### DIFF
--- a/battlearena/items.mrc
+++ b/battlearena/items.mrc
@@ -1186,12 +1186,10 @@ alias item.food {
 
     if ($readini($char($2), info, flag) = $null)  { writeini $char($2) basestats %food.type %target.stat }
     if ($readini($char($2), info, flag) != $null)  { writeini $char($2) battle %food.type %target.stat }
-
-    if (%battleis != on) { 
-      set %target.stat $readini($char($2), battle, %food.type)
-      inc %target.stat %food.bonus
-      writeini $char($2) battle %food.type %target.stat 
-    }
+ 
+    set %target.stat $readini($char($2), battle, %food.type)
+    inc %target.stat %food.bonus
+    writeini $char($2) battle %food.type %target.stat 
 
   }
 


### PR DESCRIPTION
If the battle is on, +stat items can be used, and they will not just disappear from players inventory.

Disadvantage of this solution is, that items can be used in capped battles to increase stat for that one battle. However, when the battle ends, stats are increased normally, so I don't think it's a big deal.

This is one of the solutions, the other is to completly block user from using +stat items while battle is on. So, if you feel like "the other" solution is better, just ignore this pull request :P. Anyway, should fix #20 