### PR TITLE
Shop now shows correct currencies for certain portals

### DIFF
--- a/battlearena/shop.mrc
+++ b/battlearena/shop.mrc
@@ -1984,32 +1984,32 @@ alias shop.portal {
 
     if (%portals.bstmen != $null) {  
       $display.private.message.delay.custom(2These portal items are paid for with 4BeastmenSeals2: %portals.bstmen, 1)  
-      if (%portals.bstmen2 != $null) { $display.private.message(2 $+ %portals.bstmen2)  }
+      if (%portals.bstmen2 != $null) { $display.private.message.delay.custom(2 $+ %portals.bstmen2, 1)  }
     }
 
     if (%portals.kindred != $null) {  
       $display.private.message.delay.custom(2These portal items are paid for with 4KindredSeals2: %portals.kindred, 2)  
-      if (%portals.kindred2 != $null) {  $display.private.message(2 $+ %portals.kindred2)  }
+      if (%portals.kindred2 != $null) {  $display.private.message.delay.custom(2 $+ %portals.kindred2, 2)  }
     }
 
     if (%portals.kindredcrest != $null) {  
       $display.private.message.delay.custom(2These portal items are paid for with 4KindredCrests2: %portals.kindredcrest, 3)  
-      if (%portals.kindredcrest2 != $null) {  $display.private.message(2 $+ %portals.kindredcrest2)  }
+      if (%portals.kindredcrest2 != $null) {  $display.private.message.delay.custom(2 $+ %portals.kindredcrest2, 3)  }
     }
 
     if (%portals.highkindredcrest != $null) {  
       $display.private.message.delay.custom(2These portal items are paid for with 4HighKindredCrests2: %portals.highkindredcrest, 3) 
-      if (%portals.highkindredcrest2 != $null) {  $display.private.message(2 $+ %portals.highkindredcrest2)  }
+      if (%portals.highkindredcrest2 != $null) {  $display.private.message.delay.custom(2 $+ %portals.highkindredcrest2, 3)  }
     }
 
     if (%portals.shadow != $null) {  
       $display.private.message.delay.custom(2These shadow portal items are paid for with 4HighKindredCrests2 and are uncapped: %portals.shadow, 3) 
-      if (%portals.highkindredcrest2 != $null) {  $display.private.message(2 $+ %portals.shadow2)  }
+      if (%portals.highkindredcrest2 != $null) {  $display.private.message.delay.custom(2 $+ %portals.shadow2, 3)  }
     }
 
     if (%portals.sacredkindredcrest != $null) {  
       $display.private.message.delay.custom(2These portal items are paid for with 4SacredKindredCrests2: %portals.sacredkindredcrest, 3) 
-      if (%portals.sacredkindredcrest2 != $null) {  $display.private.message(2 $+ %portals.sacredkindredcrest2)  }
+      if (%portals.sacredkindredcrest2 != $null) {  $display.private.message.delay.custom(2 $+ %portals.sacredkindredcrest2, 3)  }
     }
 
     if ((((((%portals.kindred = $null) && (%portals.bstmen = $null) && (%portals.kindredcrest = $null) && (%portals.shadow = $null) && (%portals.sacredkindredcrest = $null) && (%portals.highkindredcrest = $null)))))) { $display.private.message(4There are no portal items available for purchase right now)  }


### PR DESCRIPTION
Fixed problem with missing delays, previously !shop list portals made a small mess with some portals and showed them under incorrect currencies.

```
These portal items are paid for with BeastmenSeals: AlliedTrainingPaper(5), WormFood(5), DemonBell(10), BombShard(10), ArmosMedallian(15), BookOfMudora(15), HeraKey(15), VirilityCan(15), SuspiciousLookingEye(15), CorruptWormFood(15), BloodySpine(15), DungeonMap(15)
MillennialFairPass(10)
AvatarBlood(20), OldOrcBow(20), MechanicalEye(15), MechanicalWorm(15), MechanicalSkull(15), Plantera'sBulb(15), EnergyElements(15), SmelterDemonSoul(20)
These portal items are paid for with KindredSeals: IgnisFatuus(20), BanishingCharm(20), RottingOrb(25), NewsOrb(20), GemOfTheNorth(15), GemOfTheEast(15), GemOfTheSouth(15), GemOfTheWest(15), LachesisOrb(20), TavnaziaPass(20), YagudoDrink(20), SpheroidPlate(20)
```

Thanks to Fasa, who reported the problem.