### PR TITLE
Fix for exploit with equiping shield if wielded weapon is two-handed

### DIFF
--- a/battlearena/characters.mrc
+++ b/battlearena/characters.mrc
@@ -946,6 +946,7 @@ ON 50:TEXT:*equips *:*:{
   if (($3 != right) && ($3 != left)) { 
     if ($readini($dbfile(weapons.db), $3, type) = shield) { 
       if ($skillhave.check($1, DualWield) = false) { $display.message($readini(translation.dat, errors, Can'tDualWield), public) | halt }
+      if ($readini($dbfile(weapons.db), $readini($char($1), weapons, equipped), 2Handed) = true) { $display.message(4Error: %real.name $+ 's current weapon is a two-handed weapon.) | halt }
       var %equiphand left | var %weapon.to.equip $3
     }
     if ($readini($dbfile(weapons.db), $3, type) != shield) { 
@@ -1002,6 +1003,7 @@ ON 3:TEXT:*equips *:*:{
   if (($3 != right) && ($3 != left)) { 
     if ($readini($dbfile(weapons.db), $3, type) = shield) { 
       if ($skillhave.check($1, DualWield) = false) { $display.message($readini(translation.dat, errors, Can'tDualWield), public) | halt }
+      if ($readini($dbfile(weapons.db), $readini($char($1), weapons, equipped), 2Handed) = true) { $display.private.message(4Error: %real.name $+ 's current weapon is a two-handed weapon.) | halt }
       var %equiphand left | var %weapon.to.equip $3
     }
     if ($readini($dbfile(weapons.db), $3, type) != shield) { 

--- a/battlearena/characters.mrc
+++ b/battlearena/characters.mrc
@@ -956,6 +956,7 @@ ON 50:TEXT:*equips *:*:{
   if ($3 = right) {
     if ($readini($dbfile(weapons.db), $4, type) = shield) { 
       if ($skillhave.check($1, DualWield) = false) { $display.message($readini(translation.dat, errors, Can'tDualWield), public) | halt }
+      if ($readini($dbfile(weapons.db), $readini($char($1), weapons, equipped), 2Handed) = true) { $display.message(4Error: %real.name $+ 's current weapon is a two-handed weapon.) | halt }
       var %equiphand left | var %weapon.to.equip $4
     }
     if ($readini($dbfile(weapons.db), $4, type) != shield) { 
@@ -1075,6 +1076,7 @@ on 3:TEXT:!equip *:*: {
   if ($2 = right) {
     if ($readini($dbfile(weapons.db), $3, type) = shield) { 
       if ($skillhave.check($nick, DualWield) = false) { $display.message($readini(translation.dat, errors, Can'tDualWield), public) | halt }
+      if ($readini($dbfile(weapons.db), $readini($char($nick), weapons, equipped), 2Handed) = true) { $display.private.message(4Error: Your current weapon is a two-handed weapon.) | halt }
       var %equiphand left | var %weapon.to.equip $3
     }
     if ($readini($dbfile(weapons.db), $3, type) != shield) { 


### PR DESCRIPTION
So, I found it accidentaly yesterday. In certain circumstances it was possible to equip shield even, if player wields two-handed weapon. Found two situations, where it was possible.

First variant:
- you control other player
- you don't add "left" (it can be "right", or just nothing)
- equipped thing is a shield

Example:
```
<Pentium320> baracouda equips vanirrifle
<BattleArena> baracouda has equipped vanirrifle.
<Pentium320> baracouda equips ochain
<BattleArena> baracouda has equipped ochain in his left hand.
<Pentium320> !look baracouda
<BattleArena> baracouda is wearing ArchmagePetasos on his head; AtlantianRobe+1 on his body; ArchmageTonban on his legs; ArchmageSabots on his feet; ArchmageGloves on his hands. baracouda also has Forbidden-Earrings and Forbidden-Crown equipped as accessories and is currently using the vanirrifle and ochain weapons
```

Second variant (tested it after first variant - that's why there are 2 commits, I couldn't believe it is possible):
- you equip it for yourself
- you add "right" (yes, it may sound silly, for example: !equip right ochain)
- equipped thing is a shield

Example:
```
<Pentium320> !equip lazarus
<BattleArena> Pentium320 has equipped lazarus.
<Pentium320> !equip right ochain
<BattleArena> Pentium320 has equipped ochain in his left hand.
<Pentium320> !look
<BattleArena> Pentium320 is wearing wakidokabuto on his head; wakidodomaru on his body; wakidohaidate on his legs; wakidosune-ate on his feet; wakidokote on his hands. Pentium320 also has forbidden-crown+1 and teruterubozu equipped as accessories and is currently using the lazarus and ochain weapons
```

Anyway, this pull request fixes them, though not sure, if these are the only possible exploits, and if it doesn't break something else (though, when I tested, looks like it works), please review it.