### PR TITLE
Shop level related fixes.

### DIFF
--- a/battlearena/characters.als
+++ b/battlearena/characters.als
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; characters.als
-;;;; Last updated: 01/19/17
+;;;; Last updated: 01/21/17
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -100,18 +100,20 @@ return.playerstyle {
 ; level
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 return.shoplevel {
+  ; $1 = the short name of the character to check.
+  ; $2 = if set to true, the minimum shop level will not be checked.
+  
   var %char.shoplevel $readini($char($1), stuff, shoplevel) 
   var %min.shoplevel $return.minshoplevel($1)
 
-  if (%char.shoplevel < %min.shoplevel) { writeini $char($1) stuff shoplevel %min.shoplevel | var %char.shoplevel %min.shoplevel }
+  if (!$2 && %char.shoplevel < %min.shoplevel) { writeini $char($1) stuff shoplevel %min.shoplevel | var %char.shoplevel %min.shoplevel }
 
   return %char.shoplevel
 }
 
 return.minshoplevel {
+  if ($get.level.basestats($1) <= 100) { var %min.shoplevel 1.0 }
   var %min.shoplevel $round($calc($log($get.level.basestats($1)) - 2.6),1)
-
-  if ($get.level($1) <= 100) { var %min.shoplevel 1.0 }
   if (%min.shoplevel > 5) { var %min.shoplevel 5.0 }
   return %min.shoplevel
 }
@@ -1654,3 +1656,4 @@ character.averagedmg {
 
   return %average.damage
 }
+

--- a/battlearena/shop.mrc
+++ b/battlearena/shop.mrc
@@ -1,6 +1,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;  SHOP COMMANDS
-;;;; Last updated: 01/19/17
+;;;; Last updated: 01/21/17
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 on 3:TEXT:!shop*:*: { $shop.start($1, $2, $3, $4, $5) }
@@ -2714,8 +2714,10 @@ alias shop.halloween {
 
 }
 
-alias inc.shoplevel {   
-  var %shop.level $return.shoplevel($1)
+alias inc.shoplevel {
+  ; At this point, the minimum shop level has already been checked.
+  ; Checking it again might cause just-purchased upgrades to increase the shop level too much.
+  var %shop.level $return.shoplevel($1, $true)
 
   if (($2 = $null) || ($2 <= 0)) { var %amount.to.increase .1 }
   if (($2 != $null) && ($2 > 0)) { var %amount.to.increase $calc(.1 * $2) }
@@ -2945,3 +2947,4 @@ alias shop.voucher.buy {
   ; Show a message that we did the exchange
   $display.private.message(3You have exchanged %voucher.item.price $2 $iif(%voucher.item.price > 1, vouchers, voucher) for 1 $3)
 }
+


### PR DESCRIPTION
This commit fixes an exploit that would allow the minimum shop level to be circumvented, and a bug that, in some cases, caused the shop level to increase too much when attributes are upgraded (thanks Fasa for reporting that).