### PR TITLE
Support for multiple monster spawn after death + minor fix

### DIFF
--- a/battlearena/items.mrc
+++ b/battlearena/items.mrc
@@ -81,7 +81,7 @@ alias portal.dropcheck.check {
       var %portals.line.counter 1
       while (%portals.line.counter < %portals.lines) {
         var %portal.line $read($lstfile(items_portal.lst), n, %portals.line.counter)
-        var %portal.monster $readini($dbfile(items.db), %portal.line, Monster)
+        var %portal.monster $readini($dbfile(items.db), n, %portal.line, Monster)
         if (%drops.monster isin %portal.monster) {
           if (!%dropcheck.result) { var %dropcheck.result %portal.line }
           else { %dropcheck.result = $addtok(%dropcheck.result,%portal.line,46) }


### PR DESCRIPTION
- SpawnAfterDeath now can be used for spawning multiple monsters, just separate them with dot. Should resolve #32
- Minor fix for portal dropcheck, to prevent drops line from being executed (it could break some results, for example JungleOrb drops)

As always, please recheck the code if it's correct. On my local copy works fine :)

An example with Jailor_of_Love, which for testing has:
`SpawnAfterDeath=AbsoluteVirtue.GuardDaos`

```
[00:10:06] <BattleArena> The attack did 303,242,893,696 damage to Jailor of Love! Lightning bolts shoot into Jailor of Love causing shock! [Maximum Style!]
[00:10:06] <BattleArena> Jailor of Love has been defeated by Pentium320! <<OVERKILL>>
[00:10:06] <BattleArena> Absolute Virtue looks at the heroes and says "Tell me... for what sssearcheth thou, to travel this far? Show me... by what principlesss art thou driven?"
[00:10:06] <BattleArena> Guard Daos looks at the heroes and says "Nothing will stand against me this time!"
[00:10:06] <BattleArena> Absolute Virtue has entered the battle!
[00:10:06] <BattleArena> Absolute Virtue is a tall humanoid creature. It is blue and white in color and has four wings on its back. One of the strongest monsters in all of Vana'diel and the ruler of Al'Taieu.
[00:10:06] <BattleArena> Guard Daos has entered the battle!
[00:10:06] <BattleArena> Guard Daos is a powerful being that is a combination of Daos, Gades and Amon.
...
[00:10:32] <BattleArena> [Battle Order: Pentium320, GuardDaos, AbsoluteVirtue]
```