### PR TITLE
Fix for spawning after death

### DIFF
--- a/battlearena/battlealiases.als
+++ b/battlearena/battlealiases.als
@@ -3370,14 +3370,26 @@ spawn_after_death {
     var %spawn.after.death.desc $readini($char($1), descriptions, SpawnAfterDeath)
     if (%spawn.after.death.desc != $null) { $display.message(4 $+ %spawn.after.death.desc, battle) }
 
-    ; Spawn the new monster
-    if ($isfile($boss(%monster.to.spawn)) = $true) {  .copy -o $boss(%monster.to.spawn) $char(%monster.to.spawn)  }
-    if ($isfile($mon(%monster.to.spawn)) = $true) {  .copy -o $mon(%monster.to.spawn) $char(%monster.to.spawn)  }
-    if ($isfile($npc(%monster.to.spawn)) = $true) { .copy -o $npc(%monster.to.spawn) $char(%monster.to.spawn) }
+    ; Spawn the new monster, and rename it, if monster repeats.
+    if ($isfile($boss(%monster.to.spawn)) = $true) {
+      if ($isfile($char(%monster.to.spawn)) = $true) { var %monster.to.spawn.new = %monster.to.spawn $+ %spawn.after.death.counter }
+      else { %monster.to.spawn.new = %monster.to.spawn }
+      .copy -o $boss(%monster.to.spawn) $char(%monster.to.spawn.new)
+    }
+    if ($isfile($mon(%monster.to.spawn)) = $true) {
+      if ($isfile($char(%monster.to.spawn)) = $true) { var %monster.to.spawn.new = %monster.to.spawn $+ %spawn.after.death.counter }
+      else { %monster.to.spawn.new = %monster.to.spawn }
+      .copy -o $mon(%monster.to.spawn) $char(%monster.to.spawn.new)
+    }
+    if ($isfile($npc(%monster.to.spawn)) = $true) {
+      if ($isfile($char(%monster.to.spawn)) = $true) { var %monster.to.spawn.new = %monster.to.spawn $+ %spawn.after.death.counter }
+      else { %monster.to.spawn.new = %monster.to.spawn }
+      .copy -o $npc(%monster.to.spawn) $char(%monster.to.spawn.new)
+    }
 
     ; increase the total # of monsters
-    set %battlelist.toadd $readini($txtfile(battle2.txt), Battle, List) | %battlelist.toadd = $addtok(%battlelist.toadd,%monster.to.spawn,46) | writeini $txtfile(battle2.txt) Battle List %battlelist.toadd | unset %battlelist.toadd
-    write $txtfile(battle.txt) %monster.to.spawn
+    set %battlelist.toadd $readini($txtfile(battle2.txt), Battle, List) | %battlelist.toadd = $addtok(%battlelist.toadd,%monster.to.spawn.new,46) | writeini $txtfile(battle2.txt) Battle List %battlelist.toadd | unset %battlelist.toadd
+    write $txtfile(battle.txt) %monster.to.spawn.new
     var %battlemonsters $readini($txtfile(battle2.txt), BattleInfo, Monsters) | inc %battlemonsters 1 | writeini $txtfile(battle2.txt) BattleInfo Monsters %battlemonsters
 
     ; Check for a drop


### PR DESCRIPTION
Sorry for another pull request, but actually Serpano was right, and I haven't predicted spawning same monster multiple times, so when something like that occured, previous was overwritten. That PR fixes it.

It's slightly ugly when it comes about appearance in the battle
```
[01:58:49] <BattleArena> Guard Daos has entered the battle!
[01:58:49] <BattleArena> Guard Daos is a powerful being that is a combination of Daos, Gades and Amon.
[01:58:49] <BattleArena> Guard Daos has entered the battle!
[01:58:49] <BattleArena> Guard Daos is a powerful being that is a combination of Daos, Gades and Amon.
[01:58:49] <BattleArena> Absolute Virtue has entered the battle!
[01:58:49] <BattleArena> Absolute Virtue is a tall humanoid creature. It is blue and white in color and has four wings on its back. One of the strongest monsters in all of Vana'diel and the ruler of Al'Taieu.
[01:58:49] <BattleArena> Guard Daos has entered the battle!
[01:58:49] <BattleArena> Guard Daos is a powerful being that is a combination of Daos, Gades and Amon.
```

But works:

`[01:59:01] <BattleArena> [Battle Order: Pentium320, Ravager, GuardDaos, GuardDaos2, GuardDaos3, AbsoluteVirtue]`


And sorry for small mess in this PR, it was because my previous PR was accepted in same moment, when I pushed the update, so.. Github derped, a bit :D