### PR TITLE
Fix in hullbreaker_isle

### DIFF
--- a/battlearena/dungeons/hullbreaker_isle.dungeon
+++ b/battlearena/dungeons/hullbreaker_isle.dungeon
@@ -75,5 +75,5 @@ RestoreRoom=true
 [12]
 Desc=After resting, the party moves forward. They see several broken platforms, along with the wreckage of the flagship of the dread pirate Mistbeard, The Haar. As they approach, a large Kraken and several of its arms emerge from the water.
 Battlefield=Hullbreaker Isle Wrecked Ship
-monsters=Isle_Kraken.Kraken_Arm.Kraken_Arm.Kraken_Arm.KrakenArm
+monsters=Isle_Kraken.Kraken_Arm.Kraken_Arm.Kraken_Arm.Kraken_Arm
 BossRoom=true


### PR DESCRIPTION
Minor issue with generating all monsters in final room of hullbreaker isle.

```
[02:07:47] <BattleArena> * After resting, the party moves forward. They see several broken platforms, along with the wreckage of the flagship of the dread pirate Mistbeard, The Haar. As they approach, a large Kraken and several of its arms emerge from the water.
[02:07:52] <BattleArena> Dark clouds begin to unleash a torrent of rain upon the battlefield.
[02:07:53] <BattleArena> Isle Kraken has entered the battle!
[02:07:53] <BattleArena> Isle Kraken looks at the heroes and says "...."
[02:07:56] <BattleArena> Kraken Arm has entered the battle!
[02:07:56] <BattleArena> Kraken Arm 2 has entered the battle!
[02:07:56] <BattleArena> Kraken Arm 3 has entered the battle!
[02:07:56] <BattleArena> Kraken Arm 3 has entered the battle!
...
[02:07:59] <BattleArena> [Battle Order: Pentium320, baracouda, Kraken_Arm2, Kraken_Arm3, Lara_Croft, Kraken_Arm, Isle_Kraken]
```

I think this should solve this.